### PR TITLE
Re-introduce line-splitting to Text.of

### DIFF
--- a/doc/src/text.ts
+++ b/doc/src/text.ts
@@ -68,12 +68,19 @@ export abstract class Text {
   // @internal
   protected constructor() {}
 
-  static of(text: ReadonlyArray<string>): Text {
-    if (text.length == 0) throw new RangeError("A document must have at least one line")
+  static of(text: string | ReadonlyArray<string>, lineSeparator?: string | RegExp): Text {
+    if (typeof text == "string") text = splitLines(text, lineSeparator)
+    else if (text.length == 0) throw new RangeError("A document must have at least one line")
     let length = textLength(text)
     return length < MAX_LEAF ? new TextLeaf(text, length) : TextNode.from(TextLeaf.split(text, []), length)
   }
 }
+
+export function splitLines(text: string, lineSeparator: string | RegExp = DEFAULT_SPLIT): string[] {
+  return text.split(lineSeparator)
+}
+
+const DEFAULT_SPLIT = /\r\n?|\n/
 
 class TextLeaf extends Text {
   constructor(readonly text: ReadonlyArray<string>, readonly length: number = textLength(text)) {

--- a/state/src/state.ts
+++ b/state/src/state.ts
@@ -1,4 +1,4 @@
-import {Text} from "../../doc/src/text"
+import {splitLines, Text} from "../../doc/src/text"
 import {EditorSelection} from "./selection"
 import {Plugin, StateField} from "./plugin"
 import {Transaction, MetaSlot} from "./transaction"
@@ -79,19 +79,13 @@ export class EditorState {
   get lineSeparator(): string { return this.config.lineSeparator || "\n" }
 
   // FIXME move somewhere else?
-  splitLines(text: string): string[] { return splitLines(this.config, text) }
+  splitLines(text: string): string[] { return splitLines(text, this.config.lineSeparator || undefined) }
 
   static create(config: EditorStateConfig = {}): EditorState {
     let $config = Configuration.create(config)
-    let doc = config.doc instanceof Text ? config.doc : Text.of(splitLines($config, config.doc || ""))
+    let doc = config.doc instanceof Text ? config.doc : Text.of(config.doc || "", config.lineSeparator || undefined)
     let state = new EditorState($config, doc, config.selection || EditorSelection.default)
     for (let field of $config.fields) (state as any)[field.key] = field.init(state)
     return state
   }
 }
-
-function splitLines(config: Configuration, text: string): string[] {
-  return text.split(config.lineSeparator || DEFAULT_SPLIT)
-}
-
-const DEFAULT_SPLIT = /\r\n?|\n/


### PR DESCRIPTION
I just removed line-splitting from `Text.of` in e3596536555495af136bc501282c79ef18367e07. It made a few tests a bit more awkward, but in general seemed reasonable. This commit alternatively re-introduces that behavior by moving it from state to text.