### PR TITLE
Add fake documentElement if no navigator

### DIFF
--- a/view/src/browser.ts
+++ b/view/src/browser.ts
@@ -1,6 +1,6 @@
 let [nav, doc]: [any, any] = typeof navigator != "undefined"
   ? [navigator, document]
-  : [{userAgent: "", vendor: "", platform: ""}, {}]
+  : [{userAgent: "", vendor: "", platform: ""}, {documentElement: {style: {}}}]
 
 const ie_edge = /Edge\/(\d+)/.exec(nav.userAgent)
 const ie_upto10 = /MSIE \d/.test(nav.userAgent)


### PR DESCRIPTION
Fixes #47

Verified locally that this change allows a CommonJS build to load in a Node.js environment (using [this test](https://github.com/datavis-tech/codemirror-6-experiments/blob/60905087f85d978b32dc2530c5161c0e4d9bae88/packages/codemirror-6/test.js) for [this CommonJS build](https://github.com/datavis-tech/codemirror-6-experiments/tree/60905087f85d978b32dc2530c5161c0e4d9bae88/packages/codemirror-6)).