### PR TITLE
Add package-lock.json in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+package-lock.json
 /demo/demo_built*
 /view/test/test_built*
 /.rpt2_cache


### PR DESCRIPTION
@marijnh When you install the NPM package, a package-lock.json file is created in your project.
You should exclude this file because it should not be added to your project.
I added the package-lock.json file to the .gitignore.  :)