### PR TITLE
Fix keymap type signature

### DIFF
--- a/keymap/src/keymap.ts
+++ b/keymap/src/keymap.ts
@@ -2,7 +2,7 @@ import {base, keyName} from "w3c-keyname"
 import {EditorView, handleDOMEvents} from "../../view/src"
 
 export type Command = (view: EditorView) => boolean
-export type Keymap = {[key: string]: Command}
+export type Keymap = {[key: string]: Command | undefined}
 
 const mac = typeof navigator != "undefined" ? /Mac/.test(navigator.platform) : false
 


### PR DESCRIPTION
Keymap Type must be specified that 'undefined' can be returned.

See Demo Source(`codemirror.next/demo/demo.ts`).
```javascript
keymap({
    "Mod-z": undo,
    "Mod-Shift-z": redo,
    "Mod-u": view => undoSelection(view) || true,
    [isMac ? "Mod-Shift-u" : "Alt-u"]: redoSelection,
    "Ctrl-y": isMac ? undefined : redo,
    "Shift-Tab": indentSelection
  }),
```
A compilation error occurred because "undefined" was used as the "Ctrl-y" return value.
> ` "Ctrl-y": isMac ? undefined : redo,`

@marijnh  What do you think?