### PR TITLE
Export types used in public signatures

### DIFF
--- a/view/src/index.ts
+++ b/view/src/index.ts
@@ -8,3 +8,6 @@ export {Decoration, DecorationSet, DecoratedRange, WidgetType,
 export {BlockInfo} from "./heightmap"
 export {DOMPos} from "./contentview"
 export {Slot} from "../../extension/src/extension"
+export {Rect} from "./dom"
+export {Attrs} from "./attributes"
+export {MouseSelectionUpdate} from "./input"


### PR DESCRIPTION
- `Rect`: `EditorView::coordsAtPos: (pos: number) → Rect | null`
- `MouseSelectionUpdate`: `EditorView::startMouseSelection: (event: MouseEvent, update: MouseSelectionUpdate)`
- `Attrs`: Multiple usages in `ViewField`

I'm not sure if we want to keep these as named types or resolve them to type literals in the documentation.