### PR TITLE
DNM Documentation

### DIFF
--- a/builddocs.js
+++ b/builddocs.js
@@ -1,0 +1,22 @@
+const fs = require("fs")
+const {gather} = require('../gettypes')
+const {build} = require('../builddocs')
+
+const src = process.argv[2] || "doc/src/index.ts"
+const items = gather({filename: src})
+fs.writeFileSync("tpl", Object.keys(items).map(v => `@${v}`).join("\n"))
+process.stdout.write(
+  "<meta charset='utf-8'><dl>"+
+  build(
+    {
+      name: "",
+      main: "tpl",
+      allowUnresolvedTypes: false,
+      imports: [type => {
+        let sibling = type.typeSource && type.typeSource.match(/([^/]+)\//)[1]
+        if (sibling) return "#" + sibling + "." + type.type
+      }]
+    },
+    items
+  ) + "</dl>"
+)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lezer-tree": "^0.3.0",
     "lezer-javascript": "^0.3.0",
     "lezer-css": "^0.3.0",
-    "lezer-html": "^0.3.0"
+    "lezer-html": "^0.3.0",
+    "builddocs": "git://github.com/marijnh/builddocs.git#v1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.0",


### PR DESCRIPTION
This expects builddocs and gettypes to be installed in parallel to cm6. Usage:

```sh
$ sh run_gettypes.sh view/src/index.ts # Or any other module root
```
gettypes is far from perfect, so please gather issues :) `Attrs` is not inlined correctly, and `EditorView::getEffect` is not correctly typed.