### PR TITLE
Continuous Integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language:            node_js
+node_js:
+  - stable
+
+before_install:
+  - npm install -g npm@latest
+
+install:
+  - npm install
+
+script:
+  - npm run prepare
+  - npm run test
+
+notifications:
+  email:             false


### PR DESCRIPTION
Using Travis-CI (as the main repo) for CI testing.

> Before merging, allow Travis-Ci to use this repo on https://travis-ci.org