### PR TITLE
Add scroll a given a position into the viewport

### DIFF
--- a/view/src/editorview.ts
+++ b/view/src/editorview.ts
@@ -207,6 +207,19 @@ export class EditorView {
     }
   }
 
+  /// Scrolls the given `pos` position into the viewport.
+  /// In other words, it makes `pos` visible,
+  /// without changing the current selection.
+  scrollIntoView(pos: number) {
+    const update = new ViewUpdate(this, this.state, [])
+    this.viewState.update(update, pos)
+    this.docView.update(update)
+    if (this.state.facet(styleModule) != this.styleModules) this.mountStyles()
+    this.updateAttrs()
+    this.updateState = UpdateState.Idle
+    this.requestMeasure()
+  }
+
   /// @internal
   measure() {
     if (this.measureScheduled > -1) cancelAnimationFrame(this.measureScheduled)


### PR DESCRIPTION
Start implementation for this feature.

See issue #177 

I looked into the view tests, to see how to perform the corresponding tests for this feature. I realize  heightmap is only being tested: it is the only one added in the root package.json. Should I add a new module test for this feature, and then added to package.json?

Another independent issue, is that when I compile or do `npm install` I get:

```
lang-python/src/python.ts(1,22): error TS2307: Cannot find module 'lezer-python'.
```

Is there something I'm missing?

Thanks.

Luis.