### PR TITLE
Add Number class to wordChar categoriser

### DIFF
--- a/state/src/charcategory.ts
+++ b/state/src/charcategory.ts
@@ -6,7 +6,7 @@ export enum CharCategory { Word, Space, Other }
 const nonASCIISingleCaseWordChar = /[\u00df\u0587\u0590-\u05f4\u0600-\u06ff\u3040-\u309f\u30a0-\u30ff\u3400-\u4db5\u4e00-\u9fcc\uac00-\ud7af]/
 
 let wordChar: RegExp | null
-try { wordChar = new RegExp("[\\p{Alphabetic}_]", "u") } catch (_) {}
+try { wordChar = new RegExp("[\\p{Alphabetic}\\p{Number}_]", "u") } catch (_) {}
 
 function hasWordChar(str: string): boolean {
   if (wordChar) return wordChar.test(str)

--- a/state/test/test-charcategory.ts
+++ b/state/test/test-charcategory.ts
@@ -1,0 +1,25 @@
+import {EditorState, Extension, CharCategory} from "@codemirror/next/state"
+import ist from "ist"
+
+function mk(...extensions: Extension[]) {
+  return EditorState.create({extensions})
+}
+
+describe("EditorState char categorizer", () => {
+  it("categorises into alphanumeric", () => {
+    let st = mk()
+    ist(st.charCategorizer(0)("1"), CharCategory.Word)
+    ist(st.charCategorizer(0)("a"), CharCategory.Word)
+  })
+
+  it("categorises into whitespace", () => {
+    let st = mk()
+    ist(st.charCategorizer(0)(" "), CharCategory.Space)
+  })
+
+  it("categorises into other", () => {
+    let st = mk()
+    ist(st.charCategorizer(0)("/"), CharCategory.Other)
+    ist(st.charCategorizer(0)("<"), CharCategory.Other)
+  })
+})


### PR DESCRIPTION
The word categoriser is documented as including alphanumeric characters, but the Alphabetic character class doesn't include numbers. This adds the Number character class, and a few cursory tests.

The cropped up in odd keyboard navigation with numbers, e.g. cursor skipping over all of `123+456` when navigating by group.

Hopefully this matches code style/expected test structure.