### PR TITLE
Fix shortcuts for group deletion on macOS

### DIFF
--- a/commands/src/commands.ts
+++ b/commands/src/commands.ts
@@ -649,8 +649,8 @@ export const emacsStyleKeymap: readonly KeyBinding[] = [
 ///  - Ctrl-a (Cmd-a on macOS): [`selectAll`](#commands.selectAll)
 ///  - Backspace: [`deleteCharBackward`](#commands.deleteCharBackward)
 ///  - Delete: [`deleteCharForward`](#commands.deleteCharForward)
-///  - Ctrl-Backspace (Ctrl-Alt-Backspace on macOS): [`deleteGroupBackward`](#commands.deleteGroupBackward)
-///  - Ctrl-Delete (Alt-Backspace and Alt-Delete on macOS): [`deleteGroupForward`](#commands.deleteGroupForward)
+///  - Ctrl-Backspace (Alt-Backspace on macOS): [`deleteGroupBackward`](#commands.deleteGroupBackward)
+///  - Ctrl-Delete (Alt-Delete on macOS): [`deleteGroupForward`](#commands.deleteGroupForward)
 export const standardKeymap: readonly KeyBinding[] = ([
   {key: "ArrowLeft", run: cursorCharLeft, shift: selectCharLeft},
   {key: "Mod-ArrowLeft", mac: "Alt-ArrowLeft", run: cursorGroupLeft, shift: selectGroupLeft},
@@ -683,10 +683,8 @@ export const standardKeymap: readonly KeyBinding[] = ([
 
   {key: "Backspace", run: deleteCharBackward},
   {key: "Delete", run: deleteCharForward},
-  {key: "Mod-Backspace", mac: "Ctrl-Alt-Backspace", run: deleteGroupBackward},
-  {key: "Mod-Delete", mac: "Alt-Backspace", run: deleteGroupForward},
-
-  {mac: "Alt-Delete", run: deleteGroupForward},
+  {key: "Mod-Backspace", mac: "Alt-Backspace", run: deleteGroupBackward},
+  {key: "Mod-Delete", mac: "Alt-Delete", run: deleteGroupForward},
 ] as KeyBinding[]).concat(emacsStyleKeymap.map(b => ({mac: b.key, run: b.run, shift: b.shift})))
 
 /// The default keymap. Includes all bindings from


### PR DESCRIPTION
As documented in [Key Values - MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Editing_keys), "Backspace" maps to the `delete` key on macOS, while "Delete" maps to `fn`+`delete`. Therefore, the shortcuts for group deletion on macOS should be similar to other platforms except "Mod" is replaced by "Alt". This behavior is consistent with [Mac keyboard shortcuts - Apple Support](https://support.apple.com/en-us/HT201236).