### PR TITLE
Fix npm badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CodeMirror 6 prototype
 
 [![Build Status](https://travis-ci.org/codemirror/codemirror.next.svg)](https://travis-ci.org/codemirror/codemirror.next)
-[![NPM version](https://img.shields.io/npm/v/@codemirror/next.svg)](https://www.npmjs.org/package/codemirror.next)
+[![NPM version](https://img.shields.io/npm/v/@codemirror/next.svg)](https://www.npmjs.org/package/@codemirror/next)
 
 This is the prototype of the next version of [CodeMirror](https://codemirror.net), a complete rewrite.
 


### PR DESCRIPTION
The original badge link is incorrect on npmjs.