### PR TITLE
Removed exports of EditorView and EditorState from basic-setup.ts

### DIFF
--- a/basic-setup/src/basic-setup.ts
+++ b/basic-setup/src/basic-setup.ts
@@ -75,6 +75,3 @@ export const basicSetup: Extension = [
     ...lintKeymap
   ])
 ]
-
-export {EditorView} from "@codemirror/next/view"
-export {EditorState} from "@codemirror/next/state"


### PR DESCRIPTION
I've accidentally imported `EditorView` and `EditorState` from `basic-setup` instead of `@codemirror/next/state` / `@codemirror/next/view`.

Looks like it's was exported by mistake from `basic-setup`.