### PR TITLE
Fix bool token color in one-dark theme

### DIFF
--- a/theme-one-dark/src/one-dark.ts
+++ b/theme-one-dark/src/one-dark.ts
@@ -85,7 +85,8 @@ const oneDarkHighlighter = highlighter({
   strong: {fontWeight: "bold"},
   emphasis: {fontStyle: "italic"},
   link: {color: dark, textDecoration: "underline"},
-  heading: {fontWeight: "bold", color: coral}
+  heading: {fontWeight: "bold", color: coral},
+  "atom, bool": { color: whiskey }
 })
 
 /// Extension to enable the One Dark theme.


### PR DESCRIPTION
Hey, I'm working on [a REPL](http://solid-template-explorer.netlify.app/) for a Javascript library. I've been using codemirror-next rather successfully and I (and quite some people that uses the REPL) are really happy about it.

Upgrading to the latest version, I noticed the one-dark theme being a little bit broken. I figured at first that I needed to change the order of my plugins to override the defaultHighlighter colors from the basicSetup but then found out there was still a missing piece.

Digging a bit further I think you forgot - at least - one token for booleans.

Before:
![image](https://user-images.githubusercontent.com/17355226/94250049-fd2f6700-ff20-11ea-88f7-d89887c6029e.png)

After
![image](https://user-images.githubusercontent.com/17355226/94250105-12a49100-ff21-11ea-8bcb-fd82f8f93159.png)