### PR TITLE
Set pending when compositionend event is dispatched

### DIFF
--- a/autocomplete/src/state.ts
+++ b/autocomplete/src/state.ts
@@ -137,6 +137,8 @@ export class ActiveSource {
       value = value.handleChange(tr)
     else if (tr.selection && value.state != State.Inactive)
       value = new ActiveSource(value.source, State.Inactive, false)
+    else if (event == "compositionend" && value.state != State.Pending)
+      value = new ActiveSource(value.source, State.Pending, false)
 
     for (let effect of tr.effects) {
       if (effect.is(toggleCompletionEffect)) {

--- a/view/src/input.ts
+++ b/view/src/input.ts
@@ -554,5 +554,9 @@ handlers.compositionend = view => {
   view.inputState.compositionEndedAt = Date.now()
   setTimeout(() => {
     if (!view.inputState.composing) forceClearComposition(view)
+    view.dispatch({
+      changes: view.state.changes(),
+      annotations: Transaction.userEvent.of("compositionend")
+    })
   }, 50)
 }


### PR DESCRIPTION
I noticed to change autocompletion state to `Result` when enter key is pressed with Japanese IME (e.g. [Google IME](https://www.google.co.jp/ime/)). So I can not autocomplete text.
This PR will fix it by changing autocompletion state to `Pending` when the `compositionend` event is dispatched.

| master | This PR |
| --- | --- |
| ![Kapture 2020-10-31 at 14 37 24](https://user-images.githubusercontent.com/56767/97772206-24183300-1b88-11eb-9673-064368405814.gif) | ![Kapture 2020-10-31 at 14 31 55](https://user-images.githubusercontent.com/56767/97772015-0f3aa000-1b86-11eb-8bcd-be8e1d089731.gif) |
