### PR TITLE
exposed package.json in export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "./lang-rust": "./lang-rust/dist/index.js",
     "./lang-xml": "./lang-xml/dist/index.js",
     "./lang-markdown": "./lang-markdown/dist/index.js",
-    "./theme-one-dark": "./theme-one-dark/dist/index.js"
+    "./theme-one-dark": "./theme-one-dark/dist/index.js",
+    "./package.json": "./package.json",
+    "./": "./"
   },
   "license": "(MIT OR GPL-3.0)",
   "dependencies": {


### PR DESCRIPTION
Motivation and context here:
https://github.com/snowpackjs/snowpack/discussions/1954#discussioncomment-203114

there is even a discussion to make `package.json` to be a special case but it was closed :( https://github.com/nodejs/modules/issues/445

In short, modern tooling need to be able to resolve `package.json`, hence it needs to be added to the export map.