### PR TITLE
Windows build fixes: yarn and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This is the central repository for [CodeMirror 6](https://codemirror.net/6). It 
 
 To get started, make sure you are running [node.js](https://nodejs.org/) version 14. After cloning the repository, make sure you have [yarn](https://yarnpkg.com/) installed and run
 
-    bin/cm.js install
+    node bin/cm.js install
 
 to clone the packages that make up the system, install dependencies, and build the packages. At any time you can rebuild packages, either by running `npm run prepare` in their subdirectory, or all at once with
 
-    bin/cm.js build
+    node bin/cm.js build
 
 Developing is best done by setting up
 

--- a/bin/cm.js
+++ b/bin/cm.js
@@ -60,8 +60,8 @@ function error(err) {
   process.exit(1)
 }
 
-function run(cmd, args, wd = root) {
-  return child.execFileSync(cmd, args, {cwd: wd, encoding: "utf8", stdio: ["ignore", "pipe", process.stderr]})
+function run(cmd, args, wd = root, { shell = false } = {}) {
+  return child.execFileSync(cmd, args, {shell, cwd: wd, encoding: "utf8", stdio: ["ignore", "pipe", process.stderr]})
 }
 
 function replace(file, f) {
@@ -91,7 +91,8 @@ function install(arg = null) {
   }
 
   console.log("Running yarn install")
-  run("yarn", ["install"])
+  // Needs shell: true on Windows for yarn.cmd
+  run("yarn", ["install"], root, {shell: true})
   console.log("Building modules")
   ;({packages, packageNames, buildPackages} = loadPackages())
   build()


### PR DESCRIPTION
Full fix also requires changes to buildhelper on https://github.com/codemirror/buildhelper/pull/3

With these two fixes the following work for me on Windows:

- node ./bin/cm.js install
- node ./bin/cm.js build
- node ./bin/cm.js devserver
    - rebuilds changes to demo
    - rebuilds changes to packages

See https://github.com/codemirror/codemirror.next/issues/425