### PR TITLE
Update recommended Node version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the central repository for [CodeMirror 6](https://codemirror.net/6). It holds the bug tracker and development scripts.
 
-To get started, make sure you are running [node.js](https://nodejs.org/) version 14. After cloning the repository, run
+To get started, make sure you are running [node.js](https://nodejs.org/) version 16. After cloning the repository, run
 
     node bin/cm.js install
 


### PR DESCRIPTION
Based on discussion in https://github.com/codemirror/codemirror.next/issues/541 , I figured I'd submit this small patch to update the README to recommend Node 16 rather than Node 14.