### PR TITLE
Add a flag to dev server to generate sourcemaps

### DIFF
--- a/bin/cm.js
+++ b/bin/cm.js
@@ -42,7 +42,8 @@ function help(status) {
   cm status               Output git status, when interesting, for packages
   cm build                Build the bundle files
   cm clean                Delete files created by the build
-  cm devserver            Start a dev server on port 8090
+  cm devserver [--source-map]
+                          Start a dev server on port 8090
   cm release <package> [--edit] [--version <version>]
                           Create commits to tag a release
   cm build-readme <pkg>   Regenerate the readme file for a non-core package
@@ -137,8 +138,11 @@ function startServer() {
   console.log("Dev server listening on 8090")
 }
 
-function devserver() {
-  require("@codemirror/buildhelper").watch(buildPackages.map(p => p.main).filter(f => f), [join(root, "demo/demo.ts")])
+function devserver(...args) {
+  let options = {
+    sourceMap : args.includes('--source-map')
+  }
+  require("@codemirror/buildhelper").watch(buildPackages.map(p => p.main).filter(f => f), [join(root, "demo/demo.ts")], options)
   startServer()
 }
 


### PR DESCRIPTION
To generate source maps, a developer can add the --source-map flag to the dev script or run npm run dev -- --source-map.

The source-map flag has not been mentioned in the readme file due to the following reasoning

1. Currently generating sourceMap will disable the addPureComments code
2. Source maps might slow the build process
2. People don't seem to be looking for sourceMaps till now
3. Developers who want sourceMaps will probably look at the code and easily find the option